### PR TITLE
Fixed path separator in get_output_paths (Windows)

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -107,4 +107,6 @@ module.exports = (opts) ->
     get_output_paths = (files, prefix) ->
       @util.files(files).map (f) =>
         filePath = @util.output_path(f.relative).relative
-        path.join(prefix, filePath.replace(path.extname(filePath), '.css'))
+        file = path.join(prefix, filePath.replace(path.extname(filePath), '.css'))
+        file.replace(new RegExp('\\' + path.sep, 'g'), '/')
+        

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -107,6 +107,6 @@ module.exports = (opts) ->
     get_output_paths = (files, prefix) ->
       @util.files(files).map (f) =>
         filePath = @util.output_path(f.relative).relative
-        file = path.join(prefix, filePath.replace(path.extname(filePath), '.css'))
-        file.replace(new RegExp('\\' + path.sep, 'g'), '/')
+        fN = path.join(prefix, filePath.replace(path.extname(filePath), '.css'))
+        fN.replace(new RegExp('\\' + path.sep, 'g'), '/')
         


### PR DESCRIPTION
Current code is outputting "\css\filename.css" in Windows. That doesn't work in some cases and forward slashes do work in those cases too.