### PR TITLE
wrong out_put_path when omitting the optional "out" param

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -107,6 +107,7 @@ module.exports = (opts) ->
     get_output_paths = (files, prefix) ->
       @util.files(files).map (f) =>
         filePath = @util.output_path(f.relative).relative
-        fN = path.join(prefix, filePath.replace(path.extname(filePath), '.css'))
+        extname = path.extname(filePath)
+        extname = '.css' + extname if opts.postcss
+        fN = path.join(prefix, filePath.replace(extname, '.css'))
         fN.replace(new RegExp('\\' + path.sep, 'g'), '/')
-        


### PR DESCRIPTION
Fixed wrong out_put_path when omitting the optional "out" param while using css preprocessor AND postcss. Before this bugfix files (e.g.. styles.css.sty) where referenced as "style.css.css" in html. Setting css_pipeline(files: 'assets/css/*.styl', postcss:true) fixes that issue.