### PR TITLE
Fix file extension choice in get_output_paths

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -109,5 +109,5 @@ module.exports = (opts) ->
     get_output_paths = (files, prefix) ->
       @util.files(files).map (f) =>
         filePath = @util.output_path(f.relative).relative
-        fN = path.join(prefix, filePath.replace(path.extname(filePath), '.css'))
+        fN = path.join(prefix, filePath.split('.')[0] + '.css')
         fN.replace(new RegExp('\\' + path.sep, 'g'), '/')

--- a/test/fixtures/file-ext/app.coffee
+++ b/test/fixtures/file-ext/app.coffee
@@ -1,0 +1,5 @@
+css_pipeline = require '../../..'
+
+module.exports =
+  ignores: ["**/_*", "**/.DS_Store"]
+  extensions: [css_pipeline(files: "css/**")]

--- a/test/fixtures/file-ext/css/foo.styl
+++ b/test/fixtures/file-ext/css/foo.styl
@@ -1,0 +1,3 @@
+.foo:after {
+  content: 'bar'
+}

--- a/test/fixtures/file-ext/css/main.css
+++ b/test/fixtures/file-ext/css/main.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/test/fixtures/file-ext/css/wow.css.styl
+++ b/test/fixtures/file-ext/css/wow.css.styl
@@ -1,0 +1,2 @@
+.wow
+  background: green

--- a/test/fixtures/file-ext/package.json
+++ b/test/fixtures/file-ext/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*",
+    "stylus": "*"
+  }
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -122,3 +122,16 @@ describe 'prefix', ->
   it 'should prefix output path with whatever is passed to the css function', ->
     p = path.join(@public, 'index.html')
     h.file.contains(p, "href='/css/build.css'").should.be.ok
+
+describe 'file-ext', ->
+
+  before (done) -> compile_fixture.call(@, 'file-ext', -> done())
+
+  it 'should remove all file extensions, and replace it with .css', ->
+    p1 = path.join(@public, 'css/main.css')
+    p2 = path.join(@public, 'css/wow.css')
+    p3 = path.join(@public, 'css/foo.css')
+
+    h.file.exists(p1).should.be.ok
+    h.file.exists(p2).should.be.ok
+    h.file.exists(p3).should.be.ok


### PR DESCRIPTION
Essentially, due to Roots' multipass compilation, use `path.extname` is not correct, as it returns only the *last* extension, from the docs:

```
path.extname('index.coffee.md')
// returns
'.md'
```

As roots allows for multiple extensions as per multipass, I feel it's perfectly okay to use this alternative method for grabbing the basename of the file, and just appending the '.css' extension.

Any thoughts?

cc: @johnpeele