### PR TITLE
Add absolute path from view helper example to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ You might see output like this, with each file loaded on its own:
 <link rel='stylesheet' href='/css/baz.css' />
 ```
 
+If you require absolute paths because your project has a nested structure as created by [roots-dynamic-content](https://github.com/carrot/roots-dynamic-content/) you can pass `'/'` to the helper like so:
+
+```jade
+//- layout.jade extended by posts/hello_world.jade
+!= css('/')
+```
+
 ### Options
 
 ##### files


### PR DESCRIPTION
Recycling info from https://github.com/carrot/roots-dynamic-content/issues/36#issuecomment-217881310
